### PR TITLE
perf: compress data before sending it to observe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,20 @@ upload-latest:
 
 .PHONY: test
 test:
+	gcloud pubsub topics create cloud-func-test || true # ignore errors
 	PARENT=projects/terraflood-345116 \
-	TOPIC_ID="" \
+	TOPIC_ID="projects/terraflood-345116/topics/cloud-func-test" \
 	LOCATION_ALLOWLIST=us-west2,us-west1,us-central1 \
-	python3 -m unittest discover -p '*.py'
+	python3 -m unittest discover -p '*.py'	
+	# Run this to delete the topic
+	# gcloud pubsub topics delete cloud-func-test
+
+.PHONY: test-pubsub-output
+test-pubsub-output:
+	gcloud pubsub subscriptions create cloud-func-test --topic=cloud-func-test || true
+	gcloud --format json pubsub subscriptions pull cloud-func-test
+	# Run this to delete the subscription
+	# gcloud pubsub subscriptions delete cloud-func-test
 
 .PHONY: fmt
 fmt:


### PR DESCRIPTION
This will allow us to reduce pubsub egress costs by >5x.