### PR TITLE
feat(cloud-tasks): handle pagination via cloud tasks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python
+
+ENV PATH=$PATH:/usr/local/bin/google-cloud-sdk/bin/
+
+RUN curl https://sdk.cloud.google.com > install.sh && \
+    bash install.sh --disable-prompts --install-dir=/usr/local/bin && \
+    gcloud --version && \
+    rm -rf install.sh
+
+WORKDIR /src
+
+COPY . /src
+
+RUN pip install -r requirements.txt
+
+# gcloud auth application-default login
+# gcloud auth application-default set-quota-project content-eng-colin


### PR DESCRIPTION
WIP -- Instead of handling pagination in a for loop we throw the asset type and the nextPageToken onto a cloud task. The cloud task runs this same function (hurray recurrsion) and will grab the page identified by nextPageToken and if there's a token for the next page sets that to a cloud task and so on ....

draft PR to provide a place for discussion. This needs further improvements such as better error handling so we don't ack task items when we shouldn't and the ability to handle 429's with an incremental back-off