### PR TITLE
fix: add back listing things not covered by the ListAssets change

### DIFF
--- a/main.py
+++ b/main.py
@@ -97,35 +97,6 @@ DEFAULT_ASSET_TYPES = [
 
 DEFAULT_CONTENT_TYPES = ["RESOURCE", "IAM_POLICY"]
 
-class PerProjectRegistry:
-    """
-    Helper class to collect various resources per project.
-    NOTE: if observe_gcp_kind changes, corresponding content will need to be updated
-    """
-    def __init__(
-        self,
-        list_func: Callable[[str], List[dict]],
-        observe_gcp_kind: str,
-    ) -> None:
-        self.list_func = list_func
-        self.observe_gcp_kind = observe_gcp_kind
-
-
-per_project_registry: List[PerProjectRegistry] = [
-    PerProjectRegistry(
-        list_service_accounts,
-        "https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts",
-    ),
-    PerProjectRegistry(
-        list_instance_to_instance_groups,
-        "https://cloud.google.com/asset-inventory/docs/supported-asset-types#INSTANCE_TO_INSTANCEGROUP",
-    ),
-    PerProjectRegistry(
-        list_cloud_scheduler_jobs,
-        "https://cloud.google.com/scheduler/docs/reference/rest/v1/projects.locations.jobs",
-    ),
-]
-
 
 def publish(records: List[dict], observe_gcp_kind: str):
     """
@@ -152,7 +123,7 @@ def publish(records: List[dict], observe_gcp_kind: str):
 
 
 def safe_list(
-resource: discovery.Resource, list_kwargs: dict, key: str, max_depth=1000
+    resource: discovery.Resource, list_kwargs: dict, key: str, max_depth=1000
 ) -> Iterable[Any]:
     """safe_list returns an iterable of all elements in the Resource."""
 
@@ -166,6 +137,7 @@ resource: discovery.Resource, list_kwargs: dict, key: str, max_depth=1000
         list_kwargs["pageToken"] = result["nextPageToken"]
 
     raise Exception("max_depth exceeded")
+
 
 def list_service_accounts(project_id: str) -> List[dict]:
     """
@@ -192,6 +164,7 @@ def list_service_accounts(project_id: str) -> List[dict]:
                 }
             )
     return res
+
 
 def list_instance_to_instance_groups(project_id: str) -> List[dict]:
     """
@@ -232,6 +205,7 @@ def list_instance_to_instance_groups(project_id: str) -> List[dict]:
                         )
     return res
 
+
 def list_cloud_scheduler_jobs(project_id: str) -> List[dict]:
     """
     List cloud scheduler jobs.
@@ -268,6 +242,7 @@ def list_cloud_scheduler_jobs(project_id: str) -> List[dict]:
 
     return res
 
+
 def list_projects(parent: str) -> List[dict]:
     """
     Returns a list of projects.
@@ -299,6 +274,38 @@ def list_projects(parent: str) -> List[dict]:
             )
     return res
 
+
+class PerProjectRegistry:
+    """
+    Helper class to collect various resources per project.
+    NOTE: if observe_gcp_kind changes, corresponding content will need to be updated
+    """
+
+    def __init__(
+        self,
+        list_func: Callable[[str], List[dict]],
+        observe_gcp_kind: str,
+    ) -> None:
+        self.list_func = list_func
+        self.observe_gcp_kind = observe_gcp_kind
+
+
+per_project_registry: List[PerProjectRegistry] = [
+    PerProjectRegistry(
+        list_service_accounts,
+        "https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts",
+    ),
+    PerProjectRegistry(
+        list_instance_to_instance_groups,
+        "https://cloud.google.com/asset-inventory/docs/supported-asset-types#INSTANCE_TO_INSTANCEGROUP",
+    ),
+    PerProjectRegistry(
+        list_cloud_scheduler_jobs,
+        "https://cloud.google.com/scheduler/docs/reference/rest/v1/projects.locations.jobs",
+    ),
+]
+
+
 def rest_of_assets():
     """
     Entry point for collecting assets that aren't captured in the asset export or the asset
@@ -325,7 +332,6 @@ def rest_of_assets():
                     traceback.print_exception(e)
 
 
-
 def export_assets(request):
     """
     Export assets from Google Cloud to a specified storage bucket.
@@ -337,7 +343,6 @@ def export_assets(request):
     Returns:
         A tuple containing a success message and HTTP status code.
     """
-    rest_of_assets()
     logging.info("Received export assets request")
     try:
         data = request.get_json()

--- a/main.py
+++ b/main.py
@@ -97,113 +97,11 @@ DEFAULT_ASSET_TYPES = [
 
 DEFAULT_CONTENT_TYPES = ["RESOURCE", "IAM_POLICY"]
 
-def publish(records: List[dict], observe_gcp_kind: str):
-    for r in records:
-        data = json.dumps(r).encode("utf-8")
-        original_length = len(data)
-        compressed_data = gzip.compress(data)
-
-        publisher = pubsub_v1.PublisherClient()
-        publisher.publish(
-            PUBSUB_TOPIC,
-            data=compressed_data,
-            observe_gcp_kind=observe_gcp_kind,
-            observe_original_length=str(len(data)),
-            observe_content_encoding="gzip",
-        )
-        # logging.debug(f"published {data}")
-
-
-def safe_list(
-    resource: discovery.Resource, list_kwargs: dict, key: str, max_depth=1000
-) -> Iterable[Any]:
-    """safe_list returns an iterable of all elements in the Resource."""
-
-    for i in range(max_depth):
-        result: dict = resource.list(**list_kwargs).execute()
-        for r in result.get(key, []):
-            yield r
-
-        if result.get("nextPageToken", "") == "":
-            return
-        list_kwargs["pageToken"] = result["nextPageToken"]
-
-    raise Exception("max_depth exceeded")
-
-def list_service_accounts(project_id: str) -> List[dict]:
-        res = []
-        with discovery.build("iam", "v1") as service:
-            accounts = safe_list(
-                service.projects().serviceAccounts(),
-                {"name": "projects/" + project_id},
-                "accounts",
-            )
-            for account in accounts:
-                res.append(
-                    {
-                        "projectId": project_id,
-                        "account": account,
-                    }
-                )
-        return res
-
-def list_instance_to_instance_groups(project_id: str) -> List[dict]:
-        res = []
-        with compute_v1.ZonesClient() as zones_client:
-            with compute_v1.InstanceGroupsClient() as instance_group_client:
-
-                zones = zones_client.list(project=project_id)
-
-                for zone in zones:
-                    instance_groups = instance_group_client.list(
-                        project=project_id, zone=zone.name
-                    )
-
-                    for instance_group in instance_groups:
-                        instances = instance_group_client.list_instances(
-                            project=project_id,
-                            instance_group=instance_group.name,
-                            zone=zone.name,
-                        )
-
-                        for instance in instances:
-                            res.append(
-                                {
-                                    "projectId": project_id,
-                                    "zoneName": zone.name,
-                                    "instanceGroupId": instance_group.id,
-                                    "instanceUrl": instance.instance,
-                                }
-                            )
-        return res
-
-def list_cloud_scheduler_jobs(project_id: str) -> List[dict]:
-        res = []
-
-        with discovery.build("cloudscheduler", "v1") as service:
-            locations = safe_list(
-                service.projects().locations(),
-                {"name": "projects/" + project_id},
-                "locations",
-            )
-            for l in locations:
-                jobs = safe_list(
-                    service.projects().locations().jobs(),
-                    {"parent": l["name"]},
-                    "jobs",
-                )
-                for job in jobs:
-                    res.append(
-                        {
-                            "projectId": project_id,
-                            "locationId": l["locationId"],
-                            "job": job,
-                        }
-                    )
-
-        return res
-
 class PerProjectRegistry:
+    """
+    Helper class to collect various resources per project.
+    NOTE: if observe_gcp_kind changes, corresponding content will need to be updated
+    """
     def __init__(
         self,
         list_func: Callable[[str], List[dict]],
@@ -228,7 +126,159 @@ per_project_registry: List[PerProjectRegistry] = [
     ),
 ]
 
+
+def publish(records: List[dict], observe_gcp_kind: str):
+    """
+    Publish records to pub/sub
+
+    Args:
+        records: List of JSON data to publish to pub/sub.
+        observe_gcp_kind: String with the type of data we are seeing, i.e.
+            "https://cloud.google.com/asset-inventory/docs/supported-asset-types#INSTANCE_TO_INSTANCEGROUP",
+    """
+    for r in records:
+        data = json.dumps(r).encode("utf-8")
+        original_length = len(data)
+        compressed_data = gzip.compress(data)
+
+        publisher = pubsub_v1.PublisherClient()
+        publisher.publish(
+            PUBSUB_TOPIC,
+            data=compressed_data,
+            observe_gcp_kind=observe_gcp_kind,
+            observe_original_length=str(len(data)),
+            observe_content_encoding="gzip",
+        )
+
+
+def safe_list(
+resource: discovery.Resource, list_kwargs: dict, key: str, max_depth=1000
+) -> Iterable[Any]:
+    """safe_list returns an iterable of all elements in the Resource."""
+
+    for i in range(max_depth):
+        result: dict = resource.list(**list_kwargs).execute()
+        for r in result.get(key, []):
+            yield r
+
+        if result.get("nextPageToken", "") == "":
+            return
+        list_kwargs["pageToken"] = result["nextPageToken"]
+
+    raise Exception("max_depth exceeded")
+
+def list_service_accounts(project_id: str) -> List[dict]:
+    """
+    List service accounts.
+
+    Args:
+        project_id: String container the project id we want to return service
+            accounts for
+    Returns:
+        A list of dicts with service accounts and corresponding projectId
+    """
+    res = []
+    with discovery.build("iam", "v1") as service:
+        accounts = safe_list(
+            service.projects().serviceAccounts(),
+            {"name": "projects/" + project_id},
+            "accounts",
+        )
+        for account in accounts:
+            res.append(
+                {
+                    "projectId": project_id,
+                    "account": account,
+                }
+            )
+    return res
+
+def list_instance_to_instance_groups(project_id: str) -> List[dict]:
+    """
+    List instances and their corresponding instance groups in a project
+
+    Args:
+        project_id: String containing the projectId we want instances from
+            from
+    Returns:
+        A list of dicts with instances and corresponding instance groups for project.
+    """
+    res = []
+    with compute_v1.ZonesClient() as zones_client:
+        with compute_v1.InstanceGroupsClient() as instance_group_client:
+
+            zones = zones_client.list(project=project_id)
+
+            for zone in zones:
+                instance_groups = instance_group_client.list(
+                    project=project_id, zone=zone.name
+                )
+
+                for instance_group in instance_groups:
+                    instances = instance_group_client.list_instances(
+                        project=project_id,
+                        instance_group=instance_group.name,
+                        zone=zone.name,
+                    )
+
+                    for instance in instances:
+                        res.append(
+                            {
+                                "projectId": project_id,
+                                "zoneName": zone.name,
+                                "instanceGroupId": instance_group.id,
+                                "instanceUrl": instance.instance,
+                            }
+                        )
+    return res
+
+def list_cloud_scheduler_jobs(project_id: str) -> List[dict]:
+    """
+    List cloud scheduler jobs.
+
+    Args:
+        project_id: String containing the projectId we want cloud scheduler
+            jobs from
+    Returns:
+        A list of dicts with cloud scheduler jobs and corresponding project
+            project ID and location.
+    """
+    res = []
+
+    with discovery.build("cloudscheduler", "v1") as service:
+        locations = safe_list(
+            service.projects().locations(),
+            {"name": "projects/" + project_id},
+            "locations",
+        )
+        for l in locations:
+            jobs = safe_list(
+                service.projects().locations().jobs(),
+                {"parent": l["name"]},
+                "jobs",
+            )
+            for job in jobs:
+                res.append(
+                    {
+                        "projectId": project_id,
+                        "locationId": l["locationId"],
+                        "job": job,
+                    }
+                )
+
+    return res
+
 def list_projects(parent: str) -> List[dict]:
+    """
+    Returns a list of projects.
+
+    Args:
+        parent: String containing the resource we want to collect projects from.
+    Returns:
+        A list of dicts with projects.  If the parent is a project, we only return
+        data for that project (as a list).  Otherwise we return all of the projects
+        from that parent.
+    """
     res = []
     with discovery.build("cloudresourcemanager", "v3") as service:
         if parent.startswith("projects"):
@@ -249,7 +299,11 @@ def list_projects(parent: str) -> List[dict]:
             )
     return res
 
-def rest_of_assets(request):
+def rest_of_assets():
+    """
+    Entry point for collecting assets that aren't captured in the asset export or the asset
+    feed.  This will loop through all of the functions and publish them to pubsub.
+    """
     project_records = list_projects(PARENT)
     publish(
         project_records,
@@ -283,7 +337,7 @@ def export_assets(request):
     Returns:
         A tuple containing a success message and HTTP status code.
     """
-    rest_of_assets(request)
+    rest_of_assets()
     logging.info("Received export assets request")
     try:
         data = request.get_json()

--- a/main.py
+++ b/main.py
@@ -251,13 +251,12 @@ def list_projects(parent: str) -> List[dict]:
 
 def rest_of_assets(request):
     project_records = list_projects(PARENT)
-    # logging.warning(f"project_records:{project_records}")
-    # publish(
-    #     project_records,
-    #     # If observe_gcp_kind is changed, the OPAL in terraform-observe-google may need
-    #     # to be changed.
-    #     "https://cloud.google.com/resource-manager/reference/rest/v3/projects",
-    # )
+    publish(
+        project_records,
+        # If observe_gcp_kind is changed, the OPAL in terraform-observe-google may need
+        # to be changed.
+        "https://cloud.google.com/resource-manager/reference/rest/v3/projects",
+    )
 
     if project_records:
         for p in project_records:

--- a/main.py
+++ b/main.py
@@ -1,19 +1,23 @@
 # -*- coding: utf-8 -*-
-import gzip
-import logging
-import traceback
-from unittest.mock import Mock
-from google.cloud import asset_v1, storage, pubsub_v1
-from cloudevents.http import CloudEvent
 import functions_framework
-from typing import List, Dict
-import os
+import gzip
 import json
+import logging
+import os
+import traceback
+
+from google.cloud import asset_v1, compute_v1, pubsub_v1, storage
+from google.cloud.pubsub_v1.publisher import exceptions
+from googleapiclient import discovery
+from cloudevents.http import CloudEvent
+from typing import Any, Callable, Dict, Iterable, List
+from unittest.mock import Mock
 
 # Set necessary environment variables
 PARENT = os.environ["PARENT"]
 OUTPUT_BUCKET = os.environ["OUTPUT_BUCKET"].strip()
 PUBSUB_TOPIC = os.environ["TOPIC_ID"].strip()
+
 DEFAULT_ASSET_TYPES = [
     "aiplatform.googleapis.com.*",
     "anthos.googleapis.com.*",
@@ -90,7 +94,183 @@ DEFAULT_ASSET_TYPES = [
     "vpcaccess.googleapis.com.*",
     "workflows.googleapis.com.*",
 ]
+
 DEFAULT_CONTENT_TYPES = ["RESOURCE", "IAM_POLICY"]
+
+def publish(records: List[dict], observe_gcp_kind: str):
+    for r in records:
+        data = json.dumps(r).encode("utf-8")
+        original_length = len(data)
+        compressed_data = gzip.compress(data)
+
+        publisher = pubsub_v1.PublisherClient()
+        publisher.publish(
+            PUBSUB_TOPIC,
+            data=compressed_data,
+            observe_gcp_kind=observe_gcp_kind,
+            observe_original_length=str(len(data)),
+            observe_content_encoding="gzip",
+        )
+        # logging.debug(f"published {data}")
+
+
+def safe_list(
+    resource: discovery.Resource, list_kwargs: dict, key: str, max_depth=1000
+) -> Iterable[Any]:
+    """safe_list returns an iterable of all elements in the Resource."""
+
+    for i in range(max_depth):
+        result: dict = resource.list(**list_kwargs).execute()
+        for r in result.get(key, []):
+            yield r
+
+        if result.get("nextPageToken", "") == "":
+            return
+        list_kwargs["pageToken"] = result["nextPageToken"]
+
+    raise Exception("max_depth exceeded")
+
+def list_service_accounts(project_id: str) -> List[dict]:
+        res = []
+        with discovery.build("iam", "v1") as service:
+            accounts = safe_list(
+                service.projects().serviceAccounts(),
+                {"name": "projects/" + project_id},
+                "accounts",
+            )
+            for account in accounts:
+                res.append(
+                    {
+                        "projectId": project_id,
+                        "account": account,
+                    }
+                )
+        return res
+
+def list_instance_to_instance_groups(project_id: str) -> List[dict]:
+        res = []
+        with compute_v1.ZonesClient() as zones_client:
+            with compute_v1.InstanceGroupsClient() as instance_group_client:
+
+                zones = zones_client.list(project=project_id)
+
+                for zone in zones:
+                    instance_groups = instance_group_client.list(
+                        project=project_id, zone=zone.name
+                    )
+
+                    for instance_group in instance_groups:
+                        instances = instance_group_client.list_instances(
+                            project=project_id,
+                            instance_group=instance_group.name,
+                            zone=zone.name,
+                        )
+
+                        for instance in instances:
+                            res.append(
+                                {
+                                    "projectId": project_id,
+                                    "zoneName": zone.name,
+                                    "instanceGroupId": instance_group.id,
+                                    "instanceUrl": instance.instance,
+                                }
+                            )
+        return res
+
+def list_cloud_scheduler_jobs(project_id: str) -> List[dict]:
+        res = []
+
+        with discovery.build("cloudscheduler", "v1") as service:
+            locations = safe_list(
+                service.projects().locations(),
+                {"name": "projects/" + project_id},
+                "locations",
+            )
+            for l in locations:
+                jobs = safe_list(
+                    service.projects().locations().jobs(),
+                    {"parent": l["name"]},
+                    "jobs",
+                )
+                for job in jobs:
+                    res.append(
+                        {
+                            "projectId": project_id,
+                            "locationId": l["locationId"],
+                            "job": job,
+                        }
+                    )
+
+        return res
+
+class PerProjectRegistry:
+    def __init__(
+        self,
+        list_func: Callable[[str], List[dict]],
+        observe_gcp_kind: str,
+    ) -> None:
+        self.list_func = list_func
+        self.observe_gcp_kind = observe_gcp_kind
+
+
+per_project_registry: List[PerProjectRegistry] = [
+    PerProjectRegistry(
+        list_service_accounts,
+        "https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts",
+    ),
+    PerProjectRegistry(
+        list_instance_to_instance_groups,
+        "https://cloud.google.com/asset-inventory/docs/supported-asset-types#INSTANCE_TO_INSTANCEGROUP",
+    ),
+    PerProjectRegistry(
+        list_cloud_scheduler_jobs,
+        "https://cloud.google.com/scheduler/docs/reference/rest/v1/projects.locations.jobs",
+    ),
+]
+
+def list_projects(parent: str) -> List[dict]:
+    res = []
+    with discovery.build("cloudresourcemanager", "v3") as service:
+        if parent.startswith("projects"):
+            p = service.projects().get(name=parent).execute()
+            projects = [p]
+        else:
+            projects = safe_list(
+                service.projects(),
+                {"parent": parent},
+                "projects",
+            )
+        for p in projects:
+            res.append(
+                {
+                    "parent": parent,
+                    "project": p,
+                }
+            )
+    return res
+
+def rest_of_assets(request):
+    project_records = list_projects(PARENT)
+    # logging.warning(f"project_records:{project_records}")
+    # publish(
+    #     project_records,
+    #     # If observe_gcp_kind is changed, the OPAL in terraform-observe-google may need
+    #     # to be changed.
+    #     "https://cloud.google.com/resource-manager/reference/rest/v3/projects",
+    # )
+
+    if project_records:
+        for p in project_records:
+            pid = p["project"]["projectId"]
+            # logging.warning(f"pid is {pid}")
+            for r in per_project_registry:
+                try:
+                    records = r.list_func(pid)
+                    publish(records, r.observe_gcp_kind)
+                    # logging.warning(f"records is {records}")
+                except Exception as e:
+                    traceback.print_exception(e)
+
 
 
 def export_assets(request):
@@ -104,6 +284,7 @@ def export_assets(request):
     Returns:
         A tuple containing a success message and HTTP status code.
     """
+    rest_of_assets(request)
     logging.info("Received export assets request")
     try:
         data = request.get_json()


### PR DESCRIPTION
We updated our collection to use the  Cloud Asset Inventory in tandem with asset feed.  However, these do not collect of the data we require for our GCP app to function.  This adds that functionality back in.

Limitations
We should move this all to a new cloud function but we wanted to get the functionality back ASAP.