### PR TITLE
fix:  update expected folder structure

### DIFF
--- a/main.py
+++ b/main.py
@@ -450,10 +450,8 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
         return
 
     # Extract content_type and asset_type from the GCS bucket path
-    gcs_prefix = f"{bucket.name}/"
-    path = data["name"][len(gcs_prefix) :]
-    folders = path.split("/")
-    if len(folders) < 4:
+    folders = data["name"].split("/")
+    if len(folders) < 5:
         logging.warning("Path structure unexpected, returning without further action")
         return
 


### PR DESCRIPTION
Each piece of data we receive in our `gcs_to_pubsub` function has a name that gives us an idea of the folder structure of the bucket.  Previously we calculating the bucket name size, removing that from the data name, and the figuring out the content type based on the positions of the strings relative to the `/`. 

It turns out the string we were splitting on never used the bucket name to begin with so we were just removing a pre-determined number of characters to validate the data we were getting.  A change in the bucket name increased the number of characters we were trimming which caused most of our data to fail the length validation we do since it was removing an extra `/`.

Since the `name` field doesn't use the bucket, I've changed it to just split on the `/` and the indexing that follows all now works. 