### PR TITLE
fix: update logic for ignoring temp blobs

### DIFF
--- a/main.py
+++ b/main.py
@@ -432,8 +432,8 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
         return
 
     # Skip processing if filename starts with "temp"
-    if blob.name.startswith("temp"):
-        logging.info("Blob name starts with 'temp', skipping processing")
+    if "/temp_" in blob.name:
+        logging.info("Blob name contains '/temp_', skipping processing")
         return
 
     content = blob.download_as_bytes()


### PR DESCRIPTION
Blob names don't start with `temp` but they all have `/temp_` in them.  Without this, we try to process temporary blobs that we are explicitly trying to ignore.