### PR TITLE
fix: return 200 on successful run of rest_of_assets functions

### DIFF
--- a/main.py
+++ b/main.py
@@ -306,7 +306,7 @@ per_project_registry: List[PerProjectRegistry] = [
 ]
 
 
-def rest_of_assets():
+def rest_of_assets(request):
     """
     Entry point for collecting assets that aren't captured in the asset export or the asset
     feed.  This will loop through all of the functions and publish them to pubsub.

--- a/main.py
+++ b/main.py
@@ -330,6 +330,7 @@ def rest_of_assets(request):
                     # logging.warning(f"records is {records}")
                 except Exception as e:
                     traceback.print_exception(e)
+    return "Rest of assets export triggered", 200
 
 
 def export_assets(request):


### PR DESCRIPTION
Returns a 200 and takes in the request as an input for rest_of_assets function.  This is required so the function can be made it's cloud function.