### PR TITLE
fix(file_delete): adjust the gcs_to_pubsub function so it doesn't delete the gcs file

### DIFF
--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -5,10 +5,17 @@ from main import export_assets
 
 
 class TestExportAssets(unittest.TestCase):
+    @patch("main.setup_logging")
     @patch("main.asset_v1")
     @patch("main.asset_v1.OutputConfig")
     @patch("main.asset_v1.ExportAssetsRequest")
-    def test_export_assets(self, mock_request, mock_output_config, mock_asset_v1):
+    def test_export_assets(
+        self, mock_request, mock_output_config, mock_asset_v1, mock_setup_logging
+    ):
+
+        mock_logging_client = MagicMock()
+        mock_setup_logging.return_value = mock_logging_client
+
         mock_client = MagicMock()
         mock_asset_v1.AssetServiceClient.return_value = mock_client
 
@@ -25,11 +32,12 @@ class TestExportAssets(unittest.TestCase):
         mock_client.export_assets.assert_called()
 
     # Test case for when request doesn't contain "asset_types" and/or "content_type"
+    @patch("main.setup_logging")
     @patch("main.asset_v1")
     @patch("main.asset_v1.OutputConfig")
     @patch("main.asset_v1.ExportAssetsRequest")
     def test_export_assets_no_asset_or_content_types(
-        self, mock_request, mock_output_config, mock_asset_v1
+        self, mock_request, mock_output_config, mock_asset_v1, mock_setup_logging
     ):
         mock_client = MagicMock()
         mock_asset_v1.AssetServiceClient.return_value = mock_client
@@ -44,11 +52,12 @@ class TestExportAssets(unittest.TestCase):
         mock_client.export_assets.assert_called()
 
     # Test case for when an invalid content type is provided
+    @patch("main.setup_logging")
     @patch("main.asset_v1")
     @patch("main.asset_v1.OutputConfig")
     @patch("main.asset_v1.ExportAssetsRequest")
     def test_export_assets_invalid_content_type(
-        self, mock_request, mock_output_config, mock_asset_v1
+        self, mock_request, mock_output_config, mock_asset_v1, mock_setup_logging
     ):
         mock_client = MagicMock()
         mock_asset_v1.AssetServiceClient.return_value = mock_client
@@ -64,11 +73,12 @@ class TestExportAssets(unittest.TestCase):
             export_assets(mock_request)
 
     # Test case for when `export_assets` in the Google Cloud SDK throws an exception
+    @patch("main.setup_logging")
     @patch("main.asset_v1")
     @patch("main.asset_v1.OutputConfig")
     @patch("main.asset_v1.ExportAssetsRequest")
     def test_export_assets_sdk_exception(
-        self, mock_request, mock_output_config, mock_asset_v1
+        self, mock_request, mock_output_config, mock_asset_v1, mock_setup_logging
     ):
         mock_client = MagicMock()
         mock_client.export_assets.side_effect = Exception("SDK error")


### PR DESCRIPTION
related: https://github.com/observeinc/terraform-google-collection/pull/43

This PR addresses a critical issue where our cloud function could potentially delete asset export files while they are still being written to by Google Cloud Platform. This is achieved by moving the blob deletion process to a GCS lifecycle event, rather than handling it directly in our function.


- Remove direct blob deletion from the gcs_to_pubsub function. This prevents the potential erroneous deletion of asset export files while they are still being written.
- Implement GCS lifecycle events to handle blob deletion. This allows us to rely on GCS's native capabilities to handle blob lifecycle management, making our function less error-prone.
- Implement a blob size change check. We now check for changes in the size of the blob, which indicates that it is being written to. This allows our function to wait until the blob size stabilizes before proceeding, avoiding potential read/write conflicts.
