### PR TITLE
fix: stop deleting files and exit sooner on objects we do not process

### DIFF
--- a/main.py
+++ b/main.py
@@ -445,7 +445,7 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
     # Skip processing folders
     if data["name"][-1] == "/":
         logging.info("Blob name ends in '/', skipping processing")
-        return     
+        return
 
     storage_client = storage.Client()
     bucket = storage_client.get_bucket(data["bucket"])
@@ -455,7 +455,9 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
 
     # Check if blob is None
     if blob is None:
-        logging.error(f'Blob is None, returning without further action for {data["name"]}')
+        logging.error(
+            f'Blob is None, returning without further action for {data["name"]}'
+        )
         raise
 
     content = blob.download_as_bytes()
@@ -495,7 +497,7 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
             observe_gcp_content_type=content_type,
         )
 
-     # delete the file from the bucket
+    # delete the file from the bucket
     if blob.exists():
         blob.delete()
         logging.info("Blob successfully deleted")
@@ -505,9 +507,9 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
 
 
 # Manual call for testing
-# mock_request = Mock()
-# mock_request.get_json.return_value = {
-#     "asset_types": ["storage.googleapis.com.*"],
-#     "content_types": ["RESOURCE"]
-# }
-# export_assets(mock_request)
+mock_request = Mock()
+mock_request.get_json.return_value = {
+    "asset_types": ["storage.googleapis.com.*"],
+    "content_types": ["RESOURCE"],
+}
+export_assets(mock_request)

--- a/main.py
+++ b/main.py
@@ -385,8 +385,6 @@ def export_assets(request):
 
     client = asset_v1.AssetServiceClient()
 
-    timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")  # format the timestamp
-
     for content_type in content_types:
         logging.info(f"Processing content type: {content_type}")
         if content_type not in content_type_map:

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from googleapiclient import discovery
 from cloudevents.http import CloudEvent
 from typing import Any, Callable, Dict, Iterable, List
 from unittest.mock import Mock
+from datetime import datetime
 
 # Set necessary environment variables
 PARENT = os.environ["PARENT"]
@@ -374,6 +375,7 @@ def export_assets(request):
     }
 
     client = asset_v1.AssetServiceClient()
+    timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")  # format the timestamp
 
     for content_type in content_types:
         logging.info(f"Processing content type: {content_type}")

--- a/main.py
+++ b/main.py
@@ -383,9 +383,7 @@ def export_assets(request):
 
         try:
             output_config = asset_v1.OutputConfig()
-            output_config.gcs_destination.uri_prefix = (
-                f"{OUTPUT_BUCKET}/asset_export_v1/{content_type}"
-            )
+            output_config.gcs_destination.uri_prefix = f"{OUTPUT_BUCKET}/asset_export_v2_{timestamp}/{content_type}"  # use timestamped bucket name
 
             request = asset_v1.ExportAssetsRequest(
                 parent=PARENT,
@@ -443,8 +441,8 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
 
     # Check if blob is None
     if blob is None:
-        logging.warning("Blob is None, returning without further action")
-        return
+        logging.critical(f'Blob is None, returning without further action on {data["name"]}')
+        raise
 
     content = blob.download_as_bytes()
 
@@ -482,14 +480,6 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
             observe_gcp_asset_type=asset_type,
             observe_gcp_content_type=content_type,
         )
-
-    # delete the file from the bucket
-    if blob.exists():
-        blob.delete()
-        logging.info("Blob successfully deleted")
-    else:
-        logging.warning("Blob not found, could not delete")
-    return "Successfully processed file", 200
 
 
 # Manual call for testing

--- a/main.py
+++ b/main.py
@@ -510,6 +510,6 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
 # mock_request = Mock()
 # mock_request.get_json.return_value = {
 #     "asset_types": ["storage.googleapis.com.*"],
-#     "content_types": ["RESOURCE"],
+#     "content_types": ["RESOURCE"]
 # }
 # export_assets(mock_request)

--- a/main.py
+++ b/main.py
@@ -395,7 +395,9 @@ def export_assets(request):
 
         try:
             output_config = asset_v1.OutputConfig()
-            output_config.gcs_destination.uri_prefix = f"{OUTPUT_BUCKET}/asset_export_v1/{content_type}"  # use timestamped bucket name
+            output_config.gcs_destination.uri_prefix = (
+                f"{OUTPUT_BUCKET}/asset_export_v1/{content_type}"
+            )
 
             request = asset_v1.ExportAssetsRequest(
                 parent=PARENT,
@@ -431,18 +433,18 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
     Returns:
         None
     """
-    logging.debug("Cloud event triggered")
+    logging.info("Cloud event triggered")
 
     data = cloud_event.data
 
     # Skip processing if filename starts with "temp"
     if "/temp_" in data["name"]:
-        logging.warning("Blob name contains '/temp_', skipping processing")
+        logging.info("Blob name contains '/temp_', skipping processing")
         return
 
     # Skip processing folders
     if data["name"][-1] == "/":
-        logging.warning("Blob name ends in '/', skipping processing")
+        logging.info("Blob name ends in '/', skipping processing")
         return     
 
     storage_client = storage.Client()
@@ -499,7 +501,7 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
         logging.info("Blob successfully deleted")
     else:
         logging.warning("Blob not found, could not delete")
-    return "Sucessfully processed buket", 200
+    return "Successfully processed file", 200
 
 
 # Manual call for testing

--- a/main.py
+++ b/main.py
@@ -507,9 +507,9 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
 
 
 # Manual call for testing
-mock_request = Mock()
-mock_request.get_json.return_value = {
-    "asset_types": ["storage.googleapis.com.*"],
-    "content_types": ["RESOURCE"],
-}
-export_assets(mock_request)
+# mock_request = Mock()
+# mock_request.get_json.return_value = {
+#     "asset_types": ["storage.googleapis.com.*"],
+#     "content_types": ["RESOURCE"],
+# }
+# export_assets(mock_request)

--- a/main.py
+++ b/main.py
@@ -431,7 +431,7 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
     Returns:
         None
     """
-    logging.info("Cloud event triggered")
+    logging.debug("Cloud event triggered")
 
     data = cloud_event.data
 

--- a/main.py
+++ b/main.py
@@ -5,23 +5,13 @@ import json
 import logging
 import os
 import traceback
-import time
 
 from google.cloud import asset_v1, compute_v1, pubsub_v1, storage
 from google.cloud.pubsub_v1.publisher import exceptions
-from google.cloud import logging as gcloud_logging
-from google.api_core import exceptions as google_exceptions
 from googleapiclient import discovery
 from cloudevents.http import CloudEvent
 from typing import Any, Callable, Dict, Iterable, List
 from unittest.mock import Mock
-from datetime import datetime
-
-# Instantiates a client
-logging_client = gcloud_logging.Client()
-
-# Connects the logger to the root logging handler; by default, the severity level will be INFO.
-logging_client.setup_logging()
 
 # Set necessary environment variables
 PARENT = os.environ["PARENT"]
@@ -453,10 +443,8 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
 
     # Check if blob is None
     if blob is None:
-        logging.error(
-            f'Blob is None, returning without further action for {data["name"]}'
-        )
-        raise
+        logging.warning("Blob is None, returning without further action")
+        return
 
     content = blob.download_as_bytes()
 

--- a/main.py
+++ b/main.py
@@ -444,8 +444,8 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
 
     # Check if blob is None
     if blob is None:
-        logging.critical(f'Blob is None, returning without further action on {data["name"]}')
-        raise
+        # logging.critical(f'Blob is None, returning without further action on {data["name"]}')
+        raise Exception("Blob is none, throw exception and retry")
 
     content = blob.download_as_bytes()
 

--- a/main.py
+++ b/main.py
@@ -331,6 +331,7 @@ def rest_of_assets(request):
                     # logging.warning(f"records is {records}")
                 except Exception as e:
                     traceback.print_exception(e)
+    return "Rest of assets export triggered", 200
 
 
 def export_assets(request):


### PR DESCRIPTION
This PR does a few different things meant to address the triggering of GCP returning a 404 on attempts to delete blobs from our bucket:

- Move the check for a temp file earlier so we don't hold on to the instance for something we are going to ignore anyway.
- Check if the event was triggered by a folder.  Since we don't have anything process for a folder, we return and stop processing
- Stop deleting the blobs. The asset export is a (very) long running process and deleting files during the async call causes the 404s we were seeing.  In lieu of the immediate deletion, we defer to adding a bucket lifecycle policy to delete after a day.  This prevents us from prematurely deleting files but also prevents us accumulating excess storage cost.