### PR TITLE
fix(duplicates): use the long running api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ test: install
 	TASK_QUEUE=queue_placeholder \
 	GCP_REGION=gcp_placeholder \
 	SERVICE_ACCOUNT_EMAIL=nobody@observeinc.com \
+	GCS_TO_PUBSUB_CLOUD_FUNCTION=cloudfunction_placeholder \
 	python -m pytest tests/
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ install:
 
 .PHONY: test
 test: install
-	PARENT=testing \
+	PARENT=testing/test \
 	PROJECT_ID=project_placeholder \
 	TOPIC_ID=topic_placeholder \
 	OUTPUT_BUCKET=gs://bucket_placeholder \

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ test: install
 	TASK_QUEUE=queue_placeholder \
 	GCP_REGION=gcp_placeholder \
 	SERVICE_ACCOUNT_EMAIL=nobody@observeinc.com \
-	GCS_TO_PUBSUB_CLOUD_FUNCTION=cloudfunction_placeholder \
+	GCS_TO_PUBSUB_CLOUD_FUNCTION_URI=cloudfunction_placeholder \
 	python -m pytest tests/
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ test: install
 	PARENT=testing \
 	PROJECT_ID=project_placeholder \
 	TOPIC_ID=topic_placeholder \
-	OUTPUT_BUCKET=bucket_placeholder \
+	OUTPUT_BUCKET=gs://bucket_placeholder \
 	TASK_QUEUE=queue_placeholder \
 	GCP_REGION=gcp_placeholder \
 	SERVICE_ACCOUNT_EMAIL=nobody@observeinc.com \
@@ -88,4 +88,4 @@ docker/dev: docker/build
 
 .PHONY: docker/test
 docker/test: docker/build
-	docker run -it --rm -v $(PWD):/src -e PROJECT=test -e ENV=$(DOCKER_ENV) -u $(UID):$(GID) $(IMAGE_NAME) make test
+	docker run -it --rm -v $(PWD):/src -e PROJECT=test -e ENV=test -u $(UID):$(GID) $(IMAGE_NAME) make test

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ CONTAINER_NAME := observe-gcp
 PROJECT_ID ?= default_project_id
 UID := $(shell id -u)
 GID := $(shell id -g)
+DOCKER_ENV ?= dev
 BUCKET_NAME ?= observeinc
 PYTHON_FILES ?= . -name "*.py" -not -path "./env/*" -print
 SEMTAG_VERSION_SUFFIX ?= `semtag getcurrent`
@@ -56,9 +57,12 @@ install:
 .PHONY: test
 test: install
 	PARENT=testing \
-	PROJECT_ID=placeholder \
-	TOPIC_ID=placeholder \
-	OUTPUT_BUCKET=placeholder \
+	PROJECT_ID=project_placeholder \
+	TOPIC_ID=topic_placeholder \
+	OUTPUT_BUCKET=bucket_placeholder \
+	TASK_QUEUE=queue_placeholder \
+	GCP_REGION=gcp_placeholder \
+	SERVICE_ACCOUNT_EMAIL=nobody@observeinc.com \
 	python -m pytest tests/
 
 .PHONY: clean
@@ -80,8 +84,8 @@ docker/build:
 
 .PHONY: docker/dev
 docker/dev: docker/build
-	docker run -it --rm --name $(CONTAINER_NAME) -v $(PWD):/src -e PROJECT_ID=$(PROJECT_ID) -e ENV=dev -u $(UID):$(GID) $(IMAGE_NAME)
+	docker run -it --rm --name $(CONTAINER_NAME) -v $(PWD):/src -e PROJECT_ID=$(PROJECT_ID) -e ENV=$(DOCKER_ENV) -u $(UID):$(GID) $(IMAGE_NAME)
 
 .PHONY: docker/test
 docker/test: docker/build
-	docker run -it --rm -v $(PWD):/src -e PROJECT=test -e ENV=test -u $(UID):$(GID) $(IMAGE_NAME) make test
+	docker run -it --rm -v $(PWD):/src -e PROJECT=test -e ENV=$(DOCKER_ENV) -u $(UID):$(GID) $(IMAGE_NAME) make test

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ install:
 .PHONY: test
 test: install
 	PARENT=testing/test \
+	PROJECT=project_placeholder \
 	PROJECT_ID=project_placeholder \
 	TOPIC_ID=topic_placeholder \
 	OUTPUT_BUCKET=gs://bucket_placeholder \

--- a/README.md
+++ b/README.md
@@ -51,6 +51,21 @@ We use Python's unittest framework for testing. Run the test suite with:
 make test
 ```
 
+Run all tests in a specific file
+```
+python -m pytest tests/main_test.py
+```
+
+Run all tests in a specific class of a test file
+```
+python -m pytest tests/main_test.py::TestExportAssets
+```
+
+Run a specific test with a class
+```
+python -m pytest tests/main_test.py::TestExportAssets::test_export_assets
+```
+
 ## Contributing
 
 - Fork it (https://github.com/observeinc/google-cloud-functions/fork)

--- a/README.md
+++ b/README.md
@@ -2,77 +2,139 @@
 
 This is a Python-based project that uses the Google Cloud Platform (GCP) Asset API
 to ingest GCP resources. The assets are then sent to a GCP bucket and subsequently
-to a pub/sub service. On the receiving end, we poll the pub/sub for these resources
+to a pub/sub service. On the receiving end, we poll the pub/sub for these resources.
 
 ## Architecture and Design
 
-- Use the GCP Asset API to export assets to a GCP Bucket
-- Publish resources from the GCP bucket to a pub/sub service
+- Use the GCP Asset API to export assets to a GCP Bucket.
+- Process the GCS directory and check for the presence of the lock file.
+- Parse each blob (file) in the GCS directory:
+    - Skip if the blob is a directory, empty, or is the lock file.
+    - Parse the blob content into a list of JSON objects.
+- Extract the asset type and content type from each blob's path.
+- Publish the JSON objects to a pub/sub service with relevant headers.
+- Once processed, each blob is deleted from the GCS directory.
+- After all blobs are processed, the lock file is deleted.
 
 ## Installation
 
 The [`observeinc/collection/google`](https://registry.terraform.io/modules/observeinc/collection/google/latest) module installs this application as a Google Cloud function along with other required resources.
 
-
 ## Development
 
-**Requirements:**
-- A Google account with access to Google Cloud
-- A Docker installation on your machine
+### Setting up the Docker Environment
 
+To prepare your local development environment with Docker:
+
+```sh
+PROJECT_ID=foobar make docker/dev
 ```
-PROJECT_ID=foobar make dev
+
+Replace `foobar` with your actual project ID.
+
+### Setting Up the Environment for Local Development
+
+After initializing your Docker environment, set up the necessary environment variables:
+
+```sh
+export PARENT="your_value_here"
+export PROJECT="your_value_here"
+export OUTPUT_BUCKET="your_value_here"
+export PUBSUB_TOPIC="your_value_here"
+export TASK_QUEUE="your_value_here"
+export GCP_REGION="your_value_here"
+export SERVICE_ACCOUNT_EMAIL="your_value_here"
+export GCS_TO_PUBSUB_CLOUD_FUNCTION_URI="your_value_here"
 ```
 
-## Docker and Makefile Usage
+Replace `your_value_here` with the actual values for your environment.
 
-We utilize Docker and a Makefile for build and test processes.
+### Manual Testing
 
-Build the Docker image:
+The following code snippets facilitate local development and testing:
+
+```python
+# Manual call for testing
+# mock_request = Mock()
+# mock_request.get_json.return_value = {
+#     "asset_types": ["storage.googleapis.com.*"],
+#     "content_types": ["RESOURCE"],
+# }
+# export_assets(mock_request)
+
+
+# blob_path = "dev-content-eng-colin-bucket/asset_export_v2_20230809141905/RESOURCE/operation_name.txt"
+# create_cloud_task(blob_path)
+
+# data = 'asset_export_v2_20230809141905/RESOURCE/operation_name.txt'
+# response = gcs_to_pubsub(data)
+
+
+# bucket_name = "dev-content-eng-colin-bucket"
+# resource_prefix = "asset_export_v2_20230808210346/IAM_POLICY/"
+# process_gcs_directory(bucket_name, resource_prefix)
+```
+
+### Docker and Makefile Usage
+
+Utilize Docker and the Makefile to manage build and test processes:
+
+- Build the Docker image:
 
 ```sh
 make docker/build
 ```
 
-Run tests inside the Docker container:
+- Run the Docker container for development:
+
+```sh
+PROJECT_ID=foobar make docker/dev
+```
+
+- Execute tests inside the Docker container:
+
 ```sh
 make docker/test
 ```
 
-Clean the Docker images:
+- Clean up Docker images:
+
 ```sh
 make docker/clean
 ```
 
 ## Testing
 
-We use Python's unittest framework for testing. Run the test suite with:
+Use Python's `unittest` framework for testing. Run the entire test suite:
+
 ```sh
 make test
 ```
 
-Run all tests in a specific file
-```
+For specific tests, use the following commands:
+
+- Run all tests in a specific file:
+
+```sh
 python -m pytest tests/main_test.py
 ```
 
-Run all tests in a specific class of a test file
-```
+- Run all tests in a specific class of a test file:
+
+```sh
 python -m pytest tests/main_test.py::TestExportAssets
 ```
 
-Run a specific test with a class
-```
+- Execute a particular test within a class:
+
+```sh
 python -m pytest tests/main_test.py::TestExportAssets::test_export_assets
 ```
 
 ## Contributing
 
-- Fork it (https://github.com/observeinc/google-cloud-functions/fork)
-- Create your feature branch (git checkout -b feature/fooBar)
-- Commit your changes (git commit -am 'Add some fooBar')
-- Push to the branch (git push origin feature/fooBar)
-- Create a new Pull Request
-
-See https://www.notion.so/observeinc/GCP-collection-4af5eaa49951466fad879acfbc2c6cd9#107096e7e8794d5babc8ceec653a63ab
-for info on contributing to this repo.
+1. Fork the repository ([https://github.com/observeinc/google-cloud-functions/fork](https://github.com/observeinc/google-cloud-functions/fork))
+2. Create your feature branch (`git checkout -b feature/fooBar`)
+3. Commit your changes (`git commit -am 'Add some fooBar'`)
+4. Push to the branch (`git push origin feature/fooBar`)
+5. Create a new Pull Request

--- a/main.py
+++ b/main.py
@@ -445,7 +445,7 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
     # Skip processing folders
     if data["name"][-1] == "/":
         logging.info("Blob name ends in '/', skipping processing")
-        return     
+        return
 
     storage_client = storage.Client()
     bucket = storage_client.get_bucket(data["bucket"])
@@ -455,7 +455,9 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
 
     # Check if blob is None
     if blob is None:
-        logging.error(f'Blob is None, returning without further action for {data["name"]}')
+        logging.error(
+            f'Blob is None, returning without further action for {data["name"]}'
+        )
         raise
 
     content = blob.download_as_bytes()
@@ -495,7 +497,7 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
             observe_gcp_content_type=content_type,
         )
 
-     # delete the file from the bucket
+    # delete the file from the bucket
     if blob.exists():
         blob.delete()
         logging.info("Blob successfully deleted")
@@ -505,9 +507,9 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
 
 
 # Manual call for testing
-# mock_request = Mock()
-# mock_request.get_json.return_value = {
-#     "asset_types": ["storage.googleapis.com.*"],
-#     "content_types": ["RESOURCE"]
-# }
-# export_assets(mock_request)
+mock_request = Mock()
+mock_request.get_json.return_value = {
+    "asset_types": ["storage.googleapis.com.*"],
+    "content_types": ["RESOURCE"],
+}
+export_assets(mock_request)

--- a/main.py
+++ b/main.py
@@ -385,8 +385,6 @@ def export_assets(request):
 
     client = asset_v1.AssetServiceClient()
 
-    timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")  # format the timestamp
-
     for content_type in content_types:
         logging.info(f"Processing content type: {content_type}")
         if content_type not in content_type_map:

--- a/main.py
+++ b/main.py
@@ -648,7 +648,7 @@ def process_gcs_directory(bucket_name, prefix):
 # create_cloud_task(blob_path)
 
 # data = 'asset_export_v2_20230809141905/RESOURCE/operation_name.txt'
-# response = check_export_operation_status(data)
+# response = gcs_to_pubsub(data)
 
 
 # bucket_name = "dev-content-eng-colin-bucket"

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from googleapiclient import discovery
 from cloudevents.http import CloudEvent
 from typing import Any, Callable, Dict, Iterable, List
 from unittest.mock import Mock
+from datetime import datetime
 
 # Set necessary environment variables
 PARENT = os.environ["PARENT"]
@@ -374,6 +375,7 @@ def export_assets(request):
     }
 
     client = asset_v1.AssetServiceClient()
+    timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")  # format the timestamp
 
     for content_type in content_types:
         logging.info(f"Processing content type: {content_type}")

--- a/main.py
+++ b/main.py
@@ -383,9 +383,7 @@ def export_assets(request):
 
         try:
             output_config = asset_v1.OutputConfig()
-            output_config.gcs_destination.uri_prefix = (
-                f"{OUTPUT_BUCKET}/asset_export_v1/{content_type}"
-            )
+            output_config.gcs_destination.uri_prefix = f"{OUTPUT_BUCKET}/asset_export_v2_{timestamp}/{content_type}"  # use timestamped bucket name
 
             request = asset_v1.ExportAssetsRequest(
                 parent=PARENT,
@@ -443,8 +441,8 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
 
     # Check if blob is None
     if blob is None:
-        logging.warning("Blob is None, returning without further action")
-        return
+        logging.critical(f'Blob is None, returning without further action on {data["name"]}')
+        raise
 
     content = blob.download_as_bytes()
 
@@ -482,14 +480,6 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
             observe_gcp_asset_type=asset_type,
             observe_gcp_content_type=content_type,
         )
-
-    # delete the file from the bucket
-    if blob.exists():
-        blob.delete()
-        logging.info("Blob successfully deleted")
-    else:
-        logging.warning("Blob not found, could not delete")
-    return "Successfully processed file", 200
 
 
 # Manual call for testing

--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ PUBSUB_TOPIC = os.environ["TOPIC_ID"].strip()
 TASK_QUEUE = os.environ["TASK_QUEUE"].strip()
 GCP_REGION = os.environ["GCP_REGION"].strip()
 SERVICE_ACCOUNT_EMAIL = os.environ["SERVICE_ACCOUNT_EMAIL"].strip()
-GCS_TO_PUBSUB_CLOUD_FUNCTION = os.environ["GCS_TO_PUBSUB_CLOUD_FUNCTION"]
+GCS_TO_PUBSUB_CLOUD_FUNCTION_URI = os.environ["GCS_TO_PUBSUB_CLOUD_FUNCTION_URI"]
 
 DEFAULT_ASSET_TYPES = [
     "aiplatform.googleapis.com.*",
@@ -485,7 +485,7 @@ def create_cloud_task(blob_path):
     queue_path = client.queue_path(project, GCP_REGION, TASK_QUEUE)
 
     # Construct the URL for the cloud function. This URL will be hit by Cloud Tasks.
-    url = f"https://{GCP_REGION}-{project}.cloudfunctions.net/{GCS_TO_PUBSUB_CLOUD_FUNCTION}"
+    url = GCS_TO_PUBSUB_CLOUD_FUNCTION_URI
     payload = blob_path.encode()
 
     # Set the time for when you want the task to be attempted

--- a/main.py
+++ b/main.py
@@ -106,15 +106,33 @@ DEFAULT_ASSET_TYPES = [
 
 DEFAULT_CONTENT_TYPES = ["RESOURCE", "IAM_POLICY"]
 
+
+# Fetch the log level from the environment. If it's missing, default to 'WARNING'.
+log_level_str = os.environ.get("LOG_LEVEL", "WARNING").upper()
+
+# Check and set the log level
+valid_log_levels = {
+    "CRITICAL": logging.CRITICAL,
+    "ERROR": logging.ERROR,
+    "WARNING": logging.WARNING,
+    "INFO": logging.INFO,
+    "DEBUG": logging.DEBUG,
+}
+
+log_level = valid_log_levels.get(log_level_str)
+if not log_level:
+    logging.warning(f"Invalid LOG_LEVEL: {log_level_str}. Defaulting to WARNING.")
+    log_level = logging.WARNING
+
 if os.environ.get("GCF_REGION"):
     logging_client = gcloud_logging.Client()
-    logging_client.setup_logging()
+    logging_client.setup_logging(log_level)
 else:
     root = logging.getLogger()
-    root.setLevel(logging.DEBUG)
+    root.setLevel(log_level)
 
     handler = logging.StreamHandler(sys.stdout)
-    handler.setLevel(logging.DEBUG)
+    handler.setLevel(log_level)
     formatter = logging.Formatter(
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     )

--- a/main.py
+++ b/main.py
@@ -510,6 +510,6 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
 # mock_request = Mock()
 # mock_request.get_json.return_value = {
 #     "asset_types": ["storage.googleapis.com.*"],
-#     "content_types": ["RESOURCE"],
+#     "content_types": ["RESOURCE"]
 # }
 # export_assets(mock_request)

--- a/main.py
+++ b/main.py
@@ -395,7 +395,9 @@ def export_assets(request):
 
         try:
             output_config = asset_v1.OutputConfig()
-            output_config.gcs_destination.uri_prefix = f"{OUTPUT_BUCKET}/asset_export_v1/{content_type}"  # use timestamped bucket name
+            output_config.gcs_destination.uri_prefix = (
+                f"{OUTPUT_BUCKET}/asset_export_v1/{content_type}"
+            )
 
             request = asset_v1.ExportAssetsRequest(
                 parent=PARENT,
@@ -431,18 +433,18 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
     Returns:
         None
     """
-    logging.debug("Cloud event triggered")
+    logging.info("Cloud event triggered")
 
     data = cloud_event.data
 
     # Skip processing if filename starts with "temp"
     if "/temp_" in data["name"]:
-        logging.warning("Blob name contains '/temp_', skipping processing")
+        logging.info("Blob name contains '/temp_', skipping processing")
         return
 
     # Skip processing folders
     if data["name"][-1] == "/":
-        logging.warning("Blob name ends in '/', skipping processing")
+        logging.info("Blob name ends in '/', skipping processing")
         return     
 
     storage_client = storage.Client()
@@ -499,7 +501,7 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
         logging.info("Blob successfully deleted")
     else:
         logging.warning("Blob not found, could not delete")
-    return "Sucessfully processed buket", 200
+    return "Successfully processed file", 200
 
 
 # Manual call for testing

--- a/main.py
+++ b/main.py
@@ -507,9 +507,9 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
 
 
 # Manual call for testing
-mock_request = Mock()
-mock_request.get_json.return_value = {
-    "asset_types": ["storage.googleapis.com.*"],
-    "content_types": ["RESOURCE"],
-}
-export_assets(mock_request)
+# mock_request = Mock()
+# mock_request.get_json.return_value = {
+#     "asset_types": ["storage.googleapis.com.*"],
+#     "content_types": ["RESOURCE"],
+# }
+# export_assets(mock_request)

--- a/main.py
+++ b/main.py
@@ -431,7 +431,7 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
     Returns:
         None
     """
-    logging.info("Cloud event triggered")
+    logging.debug("Cloud event triggered")
 
     data = cloud_event.data
 

--- a/main.py
+++ b/main.py
@@ -651,24 +651,3 @@ def publish_to_pubsub(json_objects, asset_type, content_type):
             observe_gcp_asset_type=asset_type,
             observe_gcp_content_type=content_type,
         )
-
-
-# Manual call for testing
-# mock_request = Mock()
-# mock_request.get_json.return_value = {
-#     "asset_types": ["storage.googleapis.com.*"],
-#     "content_types": ["RESOURCE"],
-# }
-# export_assets(mock_request)
-
-
-# blob_path = "dev-content-eng-colin-bucket/asset_export_v2_20230809141905/RESOURCE/operation_name.txt"
-# create_cloud_task(blob_path)
-
-# data = 'asset_export_v2_20230809141905/RESOURCE/operation_name.txt'
-# response = gcs_to_pubsub(data)
-
-
-# bucket_name = "dev-content-eng-colin-bucket"
-# resource_prefix = "asset_export_v2_20230808210346/IAM_POLICY/"
-# process_gcs_directory(bucket_name, resource_prefix)

--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ PUBSUB_TOPIC = os.environ["TOPIC_ID"].strip()
 TASK_QUEUE = os.environ["TASK_QUEUE"].strip()
 GCP_REGION = os.environ["GCP_REGION"].strip()
 SERVICE_ACCOUNT_EMAIL = os.environ["SERVICE_ACCOUNT_EMAIL"].strip()
+GCS_TO_PUBSUB_CLOUD_FUNCTION = os.environ["GCS_TO_PUBSUB_CLOUD_FUNCTION"]
 
 DEFAULT_ASSET_TYPES = [
     "aiplatform.googleapis.com.*",
@@ -483,7 +484,7 @@ def create_cloud_task(blob_path):
     queue_path = client.queue_path(project, GCP_REGION, TASK_QUEUE)
 
     # Construct the URL for the cloud function. This URL will be hit by Cloud Tasks.
-    url = f"https://{GCP_REGION}-{project}.cloudfunctions.net/check_export_operation_status"
+    url = f"https://{GCP_REGION}-{project}.cloudfunctions.net/{GCS_TO_PUBSUB_CLOUD_FUNCTION}"
     payload = blob_path.encode()
 
     # Set the time for when you want the task to be attempted
@@ -511,7 +512,7 @@ def create_cloud_task(blob_path):
     return response
 
 
-def check_export_operation_status(request):
+def gcs_to_pubsub(request):
     logging.info("Starting to check export operation status.")
 
     gcs_path = request.data.decode("utf-8")

--- a/main.py
+++ b/main.py
@@ -5,23 +5,13 @@ import json
 import logging
 import os
 import traceback
-import time
 
 from google.cloud import asset_v1, compute_v1, pubsub_v1, storage
 from google.cloud.pubsub_v1.publisher import exceptions
-from google.cloud import logging as gcloud_logging
-from google.api_core import exceptions as google_exceptions
 from googleapiclient import discovery
 from cloudevents.http import CloudEvent
 from typing import Any, Callable, Dict, Iterable, List
 from unittest.mock import Mock
-from datetime import datetime
-
-# Instantiates a client
-logging_client = gcloud_logging.Client()
-
-# Connects the logger to the root logging handler; by default, the severity level will be INFO.
-logging_client.setup_logging()
 
 # Set necessary environment variables
 PARENT = os.environ["PARENT"]
@@ -453,10 +443,8 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
 
     # Check if blob is None
     if blob is None:
-        logging.error(
-            f'Blob is None, returning without further action for {data["name"]}'
-        )
-        raise
+        logging.warning("Blob is None, returning without further action")
+        return
 
     content = blob.download_as_bytes()
 

--- a/main.py
+++ b/main.py
@@ -486,7 +486,7 @@ def create_cloud_task(blob_path):
     payload = blob_path.encode()
 
     # Set the time for when you want the task to be attempted
-    now = datetime.utcnow() + timedelta(minutes=1)
+    now = datetime.utcnow() + timedelta(minutes=10)
     timestamp = Timestamp()
     timestamp.FromDatetime(now)
 

--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ from datetime import datetime, timedelta
 
 # Set necessary environment variables
 PARENT = os.environ["PARENT"]
+PROJECT = os.environ["PARENT"]
 OUTPUT_BUCKET = os.environ["OUTPUT_BUCKET"].strip()
 PUBSUB_TOPIC = os.environ["TOPIC_ID"].strip()
 TASK_QUEUE = os.environ["TASK_QUEUE"].strip()
@@ -478,7 +479,7 @@ def export_assets(request):
 def create_cloud_task(blob_path):
     # Initialize client
     client = tasks_v2.CloudTasksClient()
-    project = PARENT.split("/")[1]
+    project = PROJECT
     queue_path = client.queue_path(project, GCP_REGION, TASK_QUEUE)
 
     # Construct the URL for the cloud function. This URL will be hit by Cloud Tasks.

--- a/main.py
+++ b/main.py
@@ -192,7 +192,7 @@ def list_service_accounts(project_id: str) -> List[dict]:
         A list of dicts with service accounts and corresponding projectId
     """
     res = []
-    with discovery.build("iam", "v1") as service:
+    with discovery.build("iam", "v1", cache_discovery=False) as service:
         accounts = safe_list(
             service.projects().serviceAccounts(),
             {"name": "projects/" + project_id},
@@ -261,7 +261,7 @@ def list_cloud_scheduler_jobs(project_id: str) -> List[dict]:
     """
     res = []
 
-    with discovery.build("cloudscheduler", "v1") as service:
+    with discovery.build("cloudscheduler", "v1", cache_discovery=False) as service:
         locations = safe_list(
             service.projects().locations(),
             {"name": "projects/" + project_id},
@@ -297,7 +297,9 @@ def list_projects(parent: str) -> List[dict]:
         from that parent.
     """
     res = []
-    with discovery.build("cloudresourcemanager", "v3") as service:
+    with discovery.build(
+        "cloudresourcemanager", "v3", cache_discovery=False
+    ) as service:
         if parent.startswith("projects"):
             p = service.projects().get(name=parent).execute()
             projects = [p]

--- a/main.py
+++ b/main.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
-import functions_framework
 import gzip
 import json
 import logging
 import os
 import traceback
-import base64
 import sys
 
 from google.cloud import asset_v1, compute_v1, pubsub_v1, storage, tasks_v2
@@ -125,9 +123,9 @@ if not log_level:
     logging.warning(f"Invalid LOG_LEVEL: {log_level_str}. Defaulting to WARNING.")
     log_level = logging.WARNING
 
-if os.environ.get("GCF_REGION"):
+if os.environ.get("GAE_RUNTIME"):
     logging_client = gcloud_logging.Client()
-    logging_client.setup_logging(log_level)
+    logging_client.setup_logging()
 else:
     root = logging.getLogger()
     root.setLevel(log_level)

--- a/main.py
+++ b/main.py
@@ -444,8 +444,8 @@ def gcs_to_pubsub(cloud_event: CloudEvent):
 
     # Check if blob is None
     if blob is None:
-        logging.critical(f'Blob is None, returning without further action on {data["name"]}')
-        raise
+        # logging.critical(f'Blob is None, returning without further action on {data["name"]}')
+        raise Exception("Blob is none, throw exception and retry")
 
     content = blob.download_as_bytes()
 

--- a/main.py
+++ b/main.py
@@ -331,6 +331,7 @@ def rest_of_assets(request):
                     # logging.warning(f"records is {records}")
                 except Exception as e:
                     traceback.print_exception(e)
+    return "Rest of assets export triggered", 200
 
 
 def export_assets(request):

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ from datetime import datetime, timedelta
 
 # Set necessary environment variables
 PARENT = os.environ["PARENT"]
-PROJECT = os.environ["PARENT"]
+PROJECT = os.environ["PROJECT"]
 OUTPUT_BUCKET = os.environ["OUTPUT_BUCKET"].strip()
 PUBSUB_TOPIC = os.environ["TOPIC_ID"].strip()
 TASK_QUEUE = os.environ["TASK_QUEUE"].strip()

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ google-api-core==2.11.1
 google-api-python-client==2.89.0
 google-auth==2.22.0
 google-auth-httplib2==0.1.0
+google-auth-oauthlib==1.0.0
 google-cloud-access-context-manager==0.1.16
 google-cloud-appengine-logging==1.3.0
 google-cloud-asset==3.19.0
@@ -23,6 +24,7 @@ google-cloud-org-policy==1.8.1
 google-cloud-os-config==1.15.1
 google-cloud-pubsub==2.17.1
 google-cloud-storage==2.9.0
+google-cloud-tasks==2.14.1
 google-crc32c==1.5.0
 google-resumable-media==2.5.0
 googleapis-common-protos==1.59.1
@@ -32,10 +34,12 @@ grpcio-status==1.54.2
 gunicorn==20.1.0
 httplib2==0.22.0
 idna==3.4
+importlib-metadata==6.8.0
 itsdangerous==2.1.2
 Jinja2==3.1.2
 MarkupSafe==2.1.3
 mock==5.0.2
+oauthlib==3.2.2
 opentelemetry-api==1.15.0
 opentelemetry-sdk==1.15.0
 opentelemetry-semantic-conventions==0.36b0
@@ -46,6 +50,7 @@ pyasn1==0.5.0
 pyasn1-modules==0.3.0
 pyparsing==3.0.9
 requests==2.31.0
+requests-oauthlib==1.3.1
 rsa==4.9
 six==1.16.0
 typing_extensions==4.6.3
@@ -54,3 +59,4 @@ urllib3==1.26.16
 watchdog==3.0.0
 Werkzeug==2.3.6
 wrapt==1.15.0
+zipp==3.16.2

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import unittest
 from unittest.mock import patch, MagicMock
-from main import export_assets
+from main import export_assets, check_export_operation_status
 from google.cloud import storage
 from google.cloud import tasks_v2
 
@@ -161,4 +161,44 @@ class TestExportAssets(unittest.TestCase):
 
         self.assertEqual(
             response, ("Failed to export content type RESOURCE. Error: SDK error", 500)
+        )
+
+    @patch("main.process_gcs_directory")
+    @patch("main.discovery.build")
+    @patch("main.storage.Client")
+    def test_check_export_operation_status_success(
+        self, mock_storage_client, mock_discovery_build, mock_process_gcs_directory
+    ):
+        # Mock the request object
+        mock_request = MagicMock()
+        mock_request.data.decode.return_value = (
+            "test_bucket_name/test_path/operation_name.txt"
+        )
+
+        # Mock Google Cloud Storage client
+        mock_client_instance = MagicMock()
+        mock_bucket = MagicMock()
+        mock_blob = MagicMock()
+        mock_blob.download_as_text.return_value = "test_operation_name"
+
+        mock_client_instance.bucket.return_value = mock_bucket
+        mock_bucket.blob.return_value = mock_blob
+        mock_storage_client.return_value = mock_client_instance
+
+        # Mock discovery.build for Asset API client
+        mock_asset_service = MagicMock()
+        mock_operations = MagicMock()
+        mock_get_operation = MagicMock()
+        mock_operations.get.return_value = mock_get_operation
+        mock_get_operation.execute.return_value = {"done": True}
+
+        mock_asset_service.operations.return_value = mock_operations
+        mock_discovery_build.return_value = mock_asset_service
+
+        # Call the function
+        response = check_export_operation_status(mock_request)
+
+        # Assertions
+        mock_process_gcs_directory.assert_called_once_with(
+            "test_bucket_name", "test_path/"
         )

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -5,12 +5,25 @@ from main import export_assets
 
 
 class TestExportAssets(unittest.TestCase):
+    @patch("main.create_cloud_task")
+    @patch("main.storage")
     @patch("main.asset_v1")
     @patch("main.asset_v1.OutputConfig")
     @patch("main.asset_v1.ExportAssetsRequest")
-    def test_export_assets(self, mock_request, mock_output_config, mock_asset_v1):
+    def test_export_assets(
+        self,
+        mock_request,
+        mock_output_config,
+        mock_asset_v1,
+        mock_storage,
+        mock_create_cloud_task,
+    ):
         mock_client = MagicMock()
         mock_asset_v1.AssetServiceClient.return_value = mock_client
+
+        mock_operation = MagicMock()
+        mock_operation.operation.name = "mocked_operation_name"
+        mock_client.export_assets.return_value = mock_operation
 
         mock_request = MagicMock()
         request_data = {
@@ -19,10 +32,24 @@ class TestExportAssets(unittest.TestCase):
         }
         mock_request.get_json.return_value = request_data
 
+        mock_bucket = MagicMock()
+        mock_blob = MagicMock()
+        mock_storage.Client.return_value.bucket.return_value = mock_bucket
+        mock_bucket.blob.return_value = mock_blob
+
         response = export_assets(mock_request)
 
+        # Asserting the function behavior
         self.assertEqual(response, ("Asset export triggered", 200))
         mock_client.export_assets.assert_called()
+
+        # Check if create_cloud_task was called
+        self.assertEqual(mock_create_cloud_task.call_count, 2)
+
+        # Get the first set of arguments passed to create_cloud_task
+        args, _ = mock_create_cloud_task.call_args
+        self.assertTrue(args[0].startswith("bucket_placeholder/asset_export_v2_"))
+        self.assertTrue(args[0].endswith("/operation_name.txt"))
 
     # Test case for when request doesn't contain "asset_types" and/or "content_type"
     @patch("main.asset_v1")

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -52,23 +52,48 @@ class TestExportAssets(unittest.TestCase):
         self.assertTrue(args[0].endswith("/operation_name.txt"))
 
     # Test case for when request doesn't contain "asset_types" and/or "content_type"
+    @patch("main.create_cloud_task")
+    @patch("main.storage")
     @patch("main.asset_v1")
     @patch("main.asset_v1.OutputConfig")
     @patch("main.asset_v1.ExportAssetsRequest")
     def test_export_assets_no_asset_or_content_types(
-        self, mock_request, mock_output_config, mock_asset_v1
+        self,
+        mock_request,
+        mock_output_config,
+        mock_asset_v1,
+        mock_storage,
+        mock_create_cloud_task,
     ):
         mock_client = MagicMock()
         mock_asset_v1.AssetServiceClient.return_value = mock_client
 
+        mock_operation = MagicMock()
+        mock_operation.operation.name = "mocked_operation_name"
+        mock_client.export_assets.return_value = mock_operation
+
         mock_request = MagicMock()
-        request_data = {"some_other_field": "some_value"}
+        request_data = {}
         mock_request.get_json.return_value = request_data
+
+        mock_bucket = MagicMock()
+        mock_blob = MagicMock()
+        mock_storage.Client.return_value.bucket.return_value = mock_bucket
+        mock_bucket.blob.return_value = mock_blob
 
         response = export_assets(mock_request)
 
+        # Asserting the function behavior
         self.assertEqual(response, ("Asset export triggered", 200))
         mock_client.export_assets.assert_called()
+
+        # Check if create_cloud_task was called
+        self.assertEqual(mock_create_cloud_task.call_count, 2)
+
+        # Get the first set of arguments passed to create_cloud_task
+        args, _ = mock_create_cloud_task.call_args
+        self.assertTrue(args[0].startswith("bucket_placeholder/asset_export_v2_"))
+        self.assertTrue(args[0].endswith("/operation_name.txt"))
 
     # Test case for when an invalid content type is provided
     @patch("main.asset_v1")

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -7,6 +7,35 @@ from google.cloud import tasks_v2
 
 
 class TestExportAssets(unittest.TestCase):
+    def setUp(self):
+        # This method runs before every test
+        self.mock_request = MagicMock()
+
+        self.mock_client_instance = MagicMock()
+        self.mock_bucket = MagicMock()
+        self.mock_blob = MagicMock()
+
+        self.mock_asset_service = MagicMock()
+        self.mock_operations = MagicMock()
+        self.mock_get_operation = MagicMock()
+
+    def _setup_gcs_mocks(
+        self,
+        mock_storage_client,
+        bucket_name="test_bucket_name",
+        blob_text="test_operation_name",
+    ):
+        self.mock_blob.download_as_text.return_value = blob_text
+        self.mock_client_instance.bucket.return_value = self.mock_bucket
+        self.mock_bucket.blob.return_value = self.mock_blob
+        mock_storage_client.return_value = self.mock_client_instance
+
+    def _setup_asset_api_mocks(self, mock_discovery_build, operation_done=True):
+        self.mock_operations.get.return_value = self.mock_get_operation
+        self.mock_get_operation.execute.return_value = {"done": operation_done}
+        self.mock_asset_service.operations.return_value = self.mock_operations
+        mock_discovery_build.return_value = self.mock_asset_service
+
     @patch("main.create_cloud_task")
     @patch("main.storage")
     @patch("main.asset_v1")
@@ -170,33 +199,16 @@ class TestExportAssets(unittest.TestCase):
         self, mock_storage_client, mock_discovery_build, mock_process_gcs_directory
     ):
         # Mock the request object
-        mock_request = MagicMock()
-        mock_request.data.decode.return_value = (
+        self.mock_request.data.decode.return_value = (
             "test_bucket_name/test_path/operation_name.txt"
         )
 
-        # Mock Google Cloud Storage client
-        mock_client_instance = MagicMock()
-        mock_bucket = MagicMock()
-        mock_blob = MagicMock()
-        mock_blob.download_as_text.return_value = "test_operation_name"
-
-        mock_client_instance.bucket.return_value = mock_bucket
-        mock_bucket.blob.return_value = mock_blob
-        mock_storage_client.return_value = mock_client_instance
-
-        # Mock discovery.build for Asset API client
-        mock_asset_service = MagicMock()
-        mock_operations = MagicMock()
-        mock_get_operation = MagicMock()
-        mock_operations.get.return_value = mock_get_operation
-        mock_get_operation.execute.return_value = {"done": True}
-
-        mock_asset_service.operations.return_value = mock_operations
-        mock_discovery_build.return_value = mock_asset_service
+        # Set up mocks
+        self._setup_gcs_mocks(mock_storage_client)
+        self._setup_asset_api_mocks(mock_discovery_build, operation_done=True)
 
         # Call the function
-        response = check_export_operation_status(mock_request)
+        response = check_export_operation_status(self.mock_request)
 
         # Assertions
         mock_process_gcs_directory.assert_called_once_with(
@@ -209,36 +221,17 @@ class TestExportAssets(unittest.TestCase):
         self, mock_storage_client, mock_discovery_build
     ):
         # Mock the request object
-        mock_request = MagicMock()
-        mock_request.data.decode.return_value = (
+        self.mock_request.data.decode.return_value = (
             "test_bucket_name/test_path/operation_name.txt"
         )
 
-        # Mock Google Cloud Storage client
-        mock_client_instance = MagicMock()
-        mock_bucket = MagicMock()
-        mock_blob = MagicMock()
-        mock_blob.download_as_text.return_value = "test_operation_name"
-
-        mock_client_instance.bucket.return_value = mock_bucket
-        mock_bucket.blob.return_value = mock_blob
-        mock_storage_client.return_value = mock_client_instance
-
-        # Mock discovery.build for Asset API client
-        mock_asset_service = MagicMock()
-        mock_operations = MagicMock()
-        mock_get_operation = MagicMock()
-        mock_operations.get.return_value = mock_get_operation
-        mock_get_operation.execute.return_value = {
-            "done": False
-        }  # operation is not done
-
-        mock_asset_service.operations.return_value = mock_operations
-        mock_discovery_build.return_value = mock_asset_service
+        # Set up mocks
+        self._setup_gcs_mocks(mock_storage_client)
+        self._setup_asset_api_mocks(mock_discovery_build, operation_done=False)
 
         # Call the function and expect an exception
         with self.assertRaises(Exception) as context:
-            check_export_operation_status(mock_request)
+            check_export_operation_status(self.mock_request)
 
         self.assertIn(
             "Asset export operation not yet completed", str(context.exception)

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -4,7 +4,7 @@ import json
 import gzip
 import os
 from unittest.mock import ANY, patch, MagicMock
-from main import export_assets, check_export_operation_status, process_gcs_directory
+from main import export_assets, gcs_to_pubsub, process_gcs_directory
 from google.cloud import storage
 from google.cloud import tasks_v2
 
@@ -164,7 +164,7 @@ class TestCheckExportOperationStatus(BaseTest):
     @patch("main.process_gcs_directory")
     @patch("main.discovery.build")
     @patch("main.storage.Client")
-    def test_check_export_operation_status_success(
+    def test_gcs_to_pubsub_success(
         self, mock_storage_client, mock_discovery_build, mock_process_gcs_directory
     ):
         """Test successful check of export operation status."""
@@ -178,7 +178,7 @@ class TestCheckExportOperationStatus(BaseTest):
         self._setup_asset_api_mocks(mock_discovery_build, operation_done=True)
 
         # Call the function
-        response = check_export_operation_status(self.mock_request)
+        response = gcs_to_pubsub(self.mock_request)
 
         # Assertions
         mock_process_gcs_directory.assert_called_once_with(
@@ -187,7 +187,7 @@ class TestCheckExportOperationStatus(BaseTest):
 
     @patch("main.discovery.build")
     @patch("main.storage.Client")
-    def test_check_export_operation_status_operation_not_done(
+    def test_gcs_to_pubsub_operation_not_done(
         self, mock_storage_client, mock_discovery_build
     ):
         # Mock the request object
@@ -220,7 +220,7 @@ class TestCheckExportOperationStatus(BaseTest):
 
         # Call the function and expect an exception
         with self.assertRaises(Exception) as context:
-            check_export_operation_status(mock_request)
+            gcs_to_pubsub(mock_request)
 
         self.assertIn(
             "Asset export operation not yet completed", str(context.exception)


### PR DESCRIPTION
**Current Implementation:**

![GCP-current-2023-08 drawio](https://github.com/observeinc/google-cloud-functions/assets/131207535/31b21564-ae89-42b0-a22f-03ed5b768ef4)

- cloud schedule runs a cloud function
- cloud function (asset export) triggers an asset export to a gcs bucket
- the gcs bucket finalize event triggers a cloud function ( process )
- cloud function (process) processes the gcs file sends them to pub/sub and deletes the file

The issue is the process cloud function is being overzealous and deleting files that the long running export is still actively using.

**Proposed Implementation:**

![GCP-proposed-2023-08 drawio](https://github.com/observeinc/google-cloud-functions/assets/131207535/36841798-009b-4e70-966b-931300e9a530)

- cloud schedule runs a cloud function
- cloud function ( asset export )
  - triggers an asset export to a gcs bucket
  - writes the operation name to a file (lock file) in the bucket
  - queues a future task (+10 minutes) with the path to the lock file
- the task queue triggers the cloud function
- cloud function ( process )
  - reads the operation name out of the lock file
  - checks the operation status. If it's not done we exit and let the task queue handle the retry
  - checks the operation status. If the operation is done we process the files and exit successfully

Also included some QOL improvements:
- better logging
- some tests
- local development stubs

related: https://github.com/observeinc/terraform-google-collection/pull/44