### PR TITLE
Bump packaging from 23.2 to 24.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ oauthlib==3.2.2
 opentelemetry-api==1.15.0
 opentelemetry-sdk==1.15.0
 opentelemetry-semantic-conventions==0.36b0
-packaging==23.2
+packaging==24.2
 proto-plus==1.22.3
 protobuf==4.25.8
 pyasn1==0.5.1


### PR DESCRIPTION
## Summary

- Bumps `packaging` from 23.2 to 24.2 in `requirements.txt`
- Fixes Cloud Functions build failures: `wheel 0.46.3 has requirement packaging>=24.0, but you have packaging 23.2`
- Affects all runtimes (python310, python312) when deploying via `terraform-google-collection`

## Post-merge steps

After merging, the pre-built zip in the `observeinc` GCS bucket needs to be updated so that consumers of `terraform-google-collection` (which defaults to `gs://observeinc/google-cloud-functions-latest.zip`) pick up the fix:

1. Build and upload a new `google-cloud-functions-latest.zip` to the `observeinc` GCS bucket
2. Consider cutting a new release tag so users can pin to a specific version

Without this, existing deployments using the default `function_bucket`/`function_object` values in `terraform-google-collection` will continue to fail with the `packaging` dependency error.